### PR TITLE
fix(charts): builder needs access to private-registry secrets

### DIFF
--- a/charts/builder/templates/builder-clusterrole.yaml
+++ b/charts/builder/templates/builder-clusterrole.yaml
@@ -11,5 +11,8 @@ rules:
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["list"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["list","get"]
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
The deis-builder needs to have access to the private-registry secrets when using `off-cluster` registries. 

Right now, the breaking error is when using ECR as the private-registry:

```
error getting private registry details secrets "private-registry-ecr" is forbidden: User "system:serviceaccount:deis:deis-builder" cannot get secrets in the namespace "slack"
```
