### PR TITLE
fix(buildpack): use Procfile when BUILDPACK_URL is set

### DIFF
--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -142,7 +142,12 @@ func build(
 		return fmt.Errorf("running %s (%s)", strings.Join(tarCmd.Args, " "), err)
 	}
 
-	bType := getBuildTypeForDir(tmpDir)
+	var bType buildType
+	if buildPackURL != "" {
+		bType = buildTypeProcfile
+	} else {
+		bType = getBuildTypeForDir(tmpDir)
+	}
 	usingDockerfile := bType == buildTypeDockerfile
 
 	appTgzdata, err := ioutil.ReadFile(absAppTgz)


### PR DESCRIPTION
Builder uses dockerfile by default when Procfile and Dockerfile coexist, even if BUILDPACK_URL has been set.
I don't think that's reasonable, because the user sets the BUILDPACK_URL to indicate that the user wants to use the buildpack.
