### PR TITLE
chore(sshd): exclude deprecated SSHv2 key exchange algorithms

### DIFF
--- a/rootfs/etc/ssh/sshd_config
+++ b/rootfs/etc/ssh/sshd_config
@@ -6,7 +6,7 @@ UsePrivilegeSeparation yes
 KeyRegenerationInterval 3600
 ServerKeyBits 768
 SyslogFacility AUTH
-LogLevel INFO
+LogLevel VERBOSE
 LoginGraceTime 120
 PermitRootLogin yes
 StrictModes yes

--- a/rootfs/etc/ssh/sshd_config
+++ b/rootfs/etc/ssh/sshd_config
@@ -26,6 +26,6 @@ TCPKeepAlive yes
 #AcceptEnv LANG LC_*
 Subsystem sftp /usr/lib/openssh/sftp-server
 UseDNS no
-Ciphers aes128-cbc,aes192-cbc,aes256-cbc,rijndael-cbc@lysator.liu.se,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com
-Kexalgorithms diffie-hellman-group-exchange-sha256,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,curve25519-sha256@libssh.org,gss-gex-sha1-,gss-group1-sha1-,gss-group14-sha1-
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
 MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com

--- a/rootfs/etc/ssh/sshd_config
+++ b/rootfs/etc/ssh/sshd_config
@@ -26,3 +26,6 @@ TCPKeepAlive yes
 #AcceptEnv LANG LC_*
 Subsystem sftp /usr/lib/openssh/sftp-server
 UseDNS no
+Ciphers aes128-cbc,aes192-cbc,aes256-cbc,rijndael-cbc@lysator.liu.se,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com
+Kexalgorithms diffie-hellman-group-exchange-sha256,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,curve25519-sha256@libssh.org,gss-gex-sha1-,gss-group1-sha1-,gss-group14-sha1-
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com


### PR DESCRIPTION
According to: https://infosec.mozilla.org/guidelines/openssh#Configuration