### PR TITLE
feat(builder): Add DEIS_BUILDPACK_DEBUG variable to show more or less output when deploying

### DIFF
--- a/pkg/gitreceive/build.go
+++ b/pkg/gitreceive/build.go
@@ -110,6 +110,14 @@ func build(
 		}
 	}
 
+    var buildPackDebug string
+    if buildPackDebugInterface, ok := appConf.Values["DEIS_BUILDPACK_DEBUG"]; ok {
+        if bpDbgStr, ok := buildPackDebugInterface.(string); ok {
+            log.Debug("Buildpack Debug is on")
+            buildPackDebug = bpDbgStr
+        }
+    }
+
 	_, disableCaching := appConf.Values["DEIS_DISABLE_CACHE"]
 	slugBuilderInfo := NewSlugBuilderInfo(appName, gitSha.Short(), disableCaching)
 
@@ -227,6 +235,7 @@ func build(
 			cacheKey,
 			gitSha.Short(),
 			buildPackURL,
+			buildPackDebug,
 			conf.StorageType,
 			conf.SlugBuilderImage,
 			slugBuilderImagePullPolicy,

--- a/pkg/gitreceive/k8s_util.go
+++ b/pkg/gitreceive/k8s_util.go
@@ -125,6 +125,7 @@ func slugbuilderPod(
 	cacheKey,
 	gitShortHash string,
 	buildpackURL,
+	buildpackDebug,
 	storageType,
 	image string,
 	pullPolicy api.PullPolicy,
@@ -164,6 +165,10 @@ func slugbuilderPod(
 	if buildpackURL != "" {
 		addEnvToPod(pod, "BUILDPACK_URL", buildpackURL)
 	}
+
+    if buildpackDebug != "" {
+        addEnvToPod(pod, "DEIS_BUILDPACK_DEBUG", buildpackDebug)
+    }
 
 	return &pod
 }


### PR DESCRIPTION
refs teamhephy/workflow#109
refs teamhephy/slugbuilder#16

This fixes the excessive verbose output when cycling through
all buildpacks /bin/detect and the app doesn't match such buildpack

This PR forwards the variable DEIS_DEBUG_BUILDPACK to the slugbuilder