### PR TITLE
chore(glide): upgrade k8s.io/kubernetes to 1.4.12

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,11 @@
-hash: bfc6ad15f08b4cea455ad942497dac93404abff6b5dada28a119e1aade39bab4
-updated: 2020-05-01T17:39:19.947287056-04:00
+hash: b1d230440256afb57475ecd672288899e5b8dcecb4c9575d40256e0703dbda84
+updated: 2020-05-06T18:04:01.524752848-04:00
 imports:
+- name: cloud.google.com/go
+  version: 3b1ae45394a234c385be014e9a488f2bb6eef821
+  subpackages:
+  - compute/metadata
+  - internal
 - name: github.com/arschles/assert
   version: 6882f85ccdc7c1822b146d1a6b0c2c48f91b5140
 - name: github.com/aws/aws-sdk-go
@@ -70,7 +75,7 @@ imports:
   - unit
   - util
 - name: github.com/coreos/pkg
-  version: 7f080b6c11ac2d2347c3cd7521e810207ea1a041
+  version: fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8
   subpackages:
   - capnslog
   - dlopen
@@ -103,10 +108,8 @@ imports:
   - version
 - name: github.com/docker/go-metrics
   version: b619b3592b65de4f087d9f16863a7e6ff905973c
-- name: github.com/docker/go-units
-  version: 0bbddae09c5a5419a8c6dcdd7ff90da3d450393b
 - name: github.com/emicklei/go-restful
-  version: c4afa8e5421428d584b32d36d7b35f2c9ae5f823
+  version: 89ef8af493ab468a45a42bb0d89a06fccdd2fb22
   subpackages:
   - log
   - swagger
@@ -115,9 +118,10 @@ imports:
 - name: github.com/go-ini/ini
   version: 2e44421e256d82ebbf3d4d4fcabe8930b905eff3
 - name: github.com/gogo/protobuf
-  version: 82d16f734d6d871204a3feb1a73cb220cc92574c
+  version: e18d7aa8f8c624c915db340349aad4c49b10d173
   subpackages:
   - gogoproto
+  - plugin/compare
   - plugin/defaultcheck
   - plugin/description
   - plugin/embedcheck
@@ -125,7 +129,6 @@ imports:
   - plugin/equal
   - plugin/face
   - plugin/gostring
-  - plugin/grpc
   - plugin/marshalto
   - plugin/oneofcheck
   - plugin/populate
@@ -137,6 +140,7 @@ imports:
   - proto
   - protoc-gen-gogo/descriptor
   - protoc-gen-gogo/generator
+  - protoc-gen-gogo/grpc
   - protoc-gen-gogo/plugin
   - sortkeys
   - vanity
@@ -152,10 +156,11 @@ imports:
   - ptypes/duration
   - ptypes/timestamp
 - name: github.com/google/cadvisor
-  version: e47efa0e8af65e9a2a2eb2ce955e156eac067852
+  version: a726d13de8cb32860e73d72a78dc8e0124267709
   subpackages:
   - api
   - cache/memory
+  - client/v2
   - collector
   - container
   - container/common
@@ -213,7 +218,7 @@ imports:
 - name: github.com/jmespath/go-jmespath
   version: 3433f3ea46d9f8019119e7dd41274e112a2359a9
 - name: github.com/jonboulle/clockwork
-  version: 3f831b65b61282ba6bece21b91beea2edc4c887a
+  version: 72f9bd7c4e0c2a40055ab3d0f09654f730cce982
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kelseyhightower/envconfig
@@ -230,25 +235,6 @@ imports:
   version: 10cc4abfa7125aeaa6de57dd9ea6805c5b37285b
 - name: github.com/opencontainers/go-digest
   version: 4b560741809dd10de7b455081e356258c70270d0
-- name: github.com/opencontainers/runc
-  version: baf6536d6259209c3edfa2b22237af82942d3dfa
-  subpackages:
-  - libcontainer
-  - libcontainer/apparmor
-  - libcontainer/cgroups
-  - libcontainer/cgroups/fs
-  - libcontainer/cgroups/systemd
-  - libcontainer/configs
-  - libcontainer/configs/validate
-  - libcontainer/criurpc
-  - libcontainer/keys
-  - libcontainer/label
-  - libcontainer/seccomp
-  - libcontainer/selinux
-  - libcontainer/stacktrace
-  - libcontainer/system
-  - libcontainer/user
-  - libcontainer/utils
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/prometheus/client_golang
@@ -268,15 +254,13 @@ imports:
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: 490cc6eb5fa45bf8a8b7b73c8bc82a8160e8531d
+  version: 454a56f35412459b5e684fd5ec0f9211b94f002a
 - name: github.com/PuerkitoBio/purell
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
-- name: github.com/Sirupsen/logrus
-  version: 51fe59aca108dc5680109e7b2051cbdcfa5a253c
 - name: github.com/sirupsen/logrus
-  version: e8e563a8238de839b9cbbc1d9807d140a5a24a8d
+  version: 60c74ad9be0d874af0ab0daef6ab07c5c5911f0d
 - name: github.com/spf13/pflag
   version: 8e7dc108ab3a1ab6ce6d922bbaff5657b88e8e49
   repo: https://github.com/spf13/pflag
@@ -294,7 +278,7 @@ imports:
   - prettyprint
   - time
 - name: github.com/ugorji/go
-  version: f4485b318aadd133842532f841dc205a8e339d74
+  version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
   subpackages:
   - codec
   - codec/codecgen
@@ -335,14 +319,14 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/oauth2
-  version: b5adcc2dcdf009d0391547edc6ecbaff889f5bb9
+  version: 3c3a985cb79f52a3190fbc056984415ca6763d01
   subpackages:
   - google
   - internal
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 833a04a10549a95dc34458c195cbad61bbb6cb4d
+  version: 9c60d1c508f5134d1ca726b4641db998f2523357
   subpackages:
   - unix
 - name: golang.org/x/text
@@ -388,7 +372,6 @@ imports:
 - name: google.golang.org/cloud
   version: eb47ba841d53d93506cfbfbc03927daf9cc48f88
   subpackages:
-  - compute/metadata
   - internal
   - internal/opts
   - internal/transport
@@ -416,7 +399,7 @@ imports:
   - tap
   - transport
 - name: google.golang.org/protobuf
-  version: 4d5be764fb4e29cb616c984fb923b75b8d1031c6
+  version: 1f5b6fe64530cac2061a3d315b7e44966b1a200b
   subpackages:
   - encoding/prototext
   - encoding/protowire
@@ -452,8 +435,76 @@ imports:
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
   version: eca94c41d994ae2215d455ce578ae6e2dc6ee516
+- name: k8s.io/client-go
+  version: e5fcd1eb6215fb420fbfc95d7e2b3b672ab5d8e8
+  subpackages:
+  - 1.4/pkg/api
+  - 1.4/pkg/api/endpoints
+  - 1.4/pkg/api/errors
+  - 1.4/pkg/api/meta
+  - 1.4/pkg/api/meta/metatypes
+  - 1.4/pkg/api/pod
+  - 1.4/pkg/api/resource
+  - 1.4/pkg/api/service
+  - 1.4/pkg/api/unversioned
+  - 1.4/pkg/api/unversioned/validation
+  - 1.4/pkg/api/util
+  - 1.4/pkg/api/v1
+  - 1.4/pkg/api/validation
+  - 1.4/pkg/apimachinery
+  - 1.4/pkg/apimachinery/registered
+  - 1.4/pkg/apis/autoscaling
+  - 1.4/pkg/apis/batch
+  - 1.4/pkg/apis/extensions
+  - 1.4/pkg/auth/user
+  - 1.4/pkg/capabilities
+  - 1.4/pkg/conversion
+  - 1.4/pkg/conversion/queryparams
+  - 1.4/pkg/fields
+  - 1.4/pkg/labels
+  - 1.4/pkg/runtime
+  - 1.4/pkg/runtime/serializer
+  - 1.4/pkg/runtime/serializer/json
+  - 1.4/pkg/runtime/serializer/protobuf
+  - 1.4/pkg/runtime/serializer/recognizer
+  - 1.4/pkg/runtime/serializer/streaming
+  - 1.4/pkg/runtime/serializer/versioning
+  - 1.4/pkg/security/apparmor
+  - 1.4/pkg/selection
+  - 1.4/pkg/third_party/forked/golang/reflect
+  - 1.4/pkg/types
+  - 1.4/pkg/util
+  - 1.4/pkg/util/clock
+  - 1.4/pkg/util/config
+  - 1.4/pkg/util/crypto
+  - 1.4/pkg/util/errors
+  - 1.4/pkg/util/flowcontrol
+  - 1.4/pkg/util/framer
+  - 1.4/pkg/util/hash
+  - 1.4/pkg/util/integer
+  - 1.4/pkg/util/intstr
+  - 1.4/pkg/util/json
+  - 1.4/pkg/util/labels
+  - 1.4/pkg/util/net
+  - 1.4/pkg/util/net/sets
+  - 1.4/pkg/util/parsers
+  - 1.4/pkg/util/rand
+  - 1.4/pkg/util/runtime
+  - 1.4/pkg/util/sets
+  - 1.4/pkg/util/uuid
+  - 1.4/pkg/util/validation
+  - 1.4/pkg/util/validation/field
+  - 1.4/pkg/util/wait
+  - 1.4/pkg/util/yaml
+  - 1.4/pkg/version
+  - 1.4/pkg/watch
+  - 1.4/pkg/watch/versioned
+  - 1.4/rest
+  - 1.4/tools/clientcmd/api
+  - 1.4/tools/metrics
+  - 1.4/transport
 - name: k8s.io/kubernetes
-  version: 9fab05fe59fb4e02deb0f839ae2ae79954bbda4c
+  version: 19e81afecf5eb2b7838c35e2cbf776aff04dc34c
   subpackages:
   - pkg/api
   - pkg/api/endpoints
@@ -474,9 +525,9 @@ imports:
   - pkg/apis/apps
   - pkg/apis/apps/install
   - pkg/apis/apps/v1alpha1
-  - pkg/apis/authentication.k8s.io
-  - pkg/apis/authentication.k8s.io/install
-  - pkg/apis/authentication.k8s.io/v1beta1
+  - pkg/apis/authentication
+  - pkg/apis/authentication/install
+  - pkg/apis/authentication/v1beta1
   - pkg/apis/authorization
   - pkg/apis/authorization/install
   - pkg/apis/authorization/v1beta1
@@ -502,6 +553,9 @@ imports:
   - pkg/apis/rbac
   - pkg/apis/rbac/install
   - pkg/apis/rbac/v1alpha1
+  - pkg/apis/storage
+  - pkg/apis/storage/install
+  - pkg/apis/storage/v1beta1
   - pkg/auth/user
   - pkg/capabilities
   - pkg/client/cache
@@ -511,7 +565,6 @@ imports:
   - pkg/client/typed/discovery
   - pkg/client/unversioned
   - pkg/client/unversioned/clientcmd/api
-  - pkg/controller/framework
   - pkg/conversion
   - pkg/conversion/queryparams
   - pkg/fields
@@ -526,6 +579,8 @@ imports:
   - pkg/runtime/serializer/recognizer
   - pkg/runtime/serializer/streaming
   - pkg/runtime/serializer/versioning
+  - pkg/security/apparmor
+  - pkg/selection
   - pkg/types
   - pkg/util
   - pkg/util/clock
@@ -545,6 +600,7 @@ imports:
   - pkg/util/rand
   - pkg/util/runtime
   - pkg/util/sets
+  - pkg/util/uuid
   - pkg/util/validation
   - pkg/util/validation/field
   - pkg/util/wait

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b7d65a91b7b469eec143ebc3c634b9ad48bfcf0afe8a55a8c1c51006683390b1
-updated: 2020-04-28T17:02:31.359259908-04:00
+hash: bfc6ad15f08b4cea455ad942497dac93404abff6b5dada28a119e1aade39bab4
+updated: 2020-05-01T17:39:19.947287056-04:00
 imports:
 - name: github.com/arschles/assert
   version: 6882f85ccdc7c1822b146d1a6b0c2c48f91b5140
@@ -41,40 +41,55 @@ imports:
   - service/s3
   - service/sts
 - name: github.com/Azure/azure-sdk-for-go
-  version: e42f2c5809df82e0e99fcabcced1136d13924d21
+  version: 0984e0641ae43b89283223034574d6465be93bf4
   subpackages:
   - storage
-  - version
-- name: github.com/Azure/go-autorest
-  version: e727cfcfc902307f3a34d6f6ce50748ca944786a
-  subpackages:
-  - autorest
-  - autorest/adal
-  - autorest/azure
-  - autorest/date
-  - logger
-  - tracing
 - name: github.com/beorn7/perks
-  version: b965b613227fddccbfffe13eae360ed3fa822f8d
+  version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
   subpackages:
   - quantile
 - name: github.com/blang/semver
   version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/codegangsta/cli
   version: a65b733b303f0055f8d324d805f393cd3e7a7904
+- name: github.com/coreos/go-oidc
+  version: 5cf2aa52da8c574d3aa4458f471ad6ae2240fe6b
+  subpackages:
+  - http
+  - jose
+  - key
+  - oauth2
+  - oidc
+- name: github.com/coreos/go-systemd
+  version: 4484981625c1a6a2ecb40a390fcb6a9bcfee76e3
+  subpackages:
+  - activation
+  - daemon
+  - dbus
+  - journal
+  - unit
+  - util
+- name: github.com/coreos/pkg
+  version: 7f080b6c11ac2d2347c3cd7521e810207ea1a041
+  subpackages:
+  - capnslog
+  - dlopen
+  - health
+  - httputil
+  - timeutil
 - name: github.com/davecgh/go-spew
-  version: 3e6e67c4dcea3ac2f25fd4731abc0e1deaf36216
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
-- name: github.com/dgrijalva/jwt-go
-  version: 5ca80149b9d3f8b863af0e2bb6742e608603bd99
 - name: github.com/docker/distribution
   version: c77f65b80cb8579cde5e2ba38fdeb92c08827698
   repo: https://github.com/teamhephy/distribution
   vcs: git
   subpackages:
   - context
+  - digestset
   - metrics
+  - reference
   - registry/client/transport
   - registry/storage/driver
   - registry/storage/driver/azure
@@ -86,22 +101,12 @@ imports:
   - registry/storage/driver/swift
   - uuid
   - version
-- name: github.com/docker/docker
-  version: 0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d
-  subpackages:
-  - pkg/jsonmessage
-  - pkg/mount
-  - pkg/parsers
-  - pkg/symlink
-  - pkg/term
-  - pkg/timeutils
-  - pkg/units
 - name: github.com/docker/go-metrics
   version: b619b3592b65de4f087d9f16863a7e6ff905973c
 - name: github.com/docker/go-units
   version: 0bbddae09c5a5419a8c6dcdd7ff90da3d450393b
 - name: github.com/emicklei/go-restful
-  version: 777bb3f19bcafe2575ffb2a3e46af92509ae9594
+  version: c4afa8e5421428d584b32d36d7b35f2c9ae5f823
   subpackages:
   - log
   - swagger
@@ -109,12 +114,35 @@ imports:
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini
   version: 2e44421e256d82ebbf3d4d4fcabe8930b905eff3
+- name: github.com/gogo/protobuf
+  version: 82d16f734d6d871204a3feb1a73cb220cc92574c
+  subpackages:
+  - gogoproto
+  - plugin/defaultcheck
+  - plugin/description
+  - plugin/embedcheck
+  - plugin/enumstringer
+  - plugin/equal
+  - plugin/face
+  - plugin/gostring
+  - plugin/grpc
+  - plugin/marshalto
+  - plugin/oneofcheck
+  - plugin/populate
+  - plugin/size
+  - plugin/stringer
+  - plugin/testgen
+  - plugin/union
+  - plugin/unmarshal
+  - proto
+  - protoc-gen-gogo/descriptor
+  - protoc-gen-gogo/generator
+  - protoc-gen-gogo/plugin
+  - sortkeys
+  - vanity
+  - vanity/command
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
-- name: github.com/golang/groupcache
-  version: 604ed5785183e59ae2789449d89e73f3a2a77987
-  subpackages:
-  - lru
 - name: github.com/golang/protobuf
   version: 1b794fe86dd6a0c7c52ae69b5c9cb0aeedc52afa
   subpackages:
@@ -124,24 +152,46 @@ imports:
   - ptypes/duration
   - ptypes/timestamp
 - name: github.com/google/cadvisor
-  version: 546a3771589bdb356777c646c6eca24914fdd48b
+  version: e47efa0e8af65e9a2a2eb2ce955e156eac067852
   subpackages:
   - api
   - cache/memory
   - collector
   - container
+  - container/common
+  - container/docker
+  - container/libcontainer
+  - container/raw
+  - container/rkt
+  - container/systemd
+  - devicemapper
   - events
   - fs
   - healthz
   - http
+  - http/mux
   - info/v1
+  - info/v1/test
   - info/v2
+  - machine
   - manager
+  - manager/watcher
+  - manager/watcher/raw
+  - manager/watcher/rkt
   - metrics
   - pages
+  - pages/static
   - storage
   - summary
   - utils
+  - utils/cloudinfo
+  - utils/cpuload
+  - utils/cpuload/netlink
+  - utils/docker
+  - utils/oomparser
+  - utils/sysfs
+  - utils/sysinfo
+  - utils/tail
   - validate
   - version
 - name: github.com/google/gofuzz
@@ -156,8 +206,14 @@ imports:
   version: e444e69cbd2e2e3e0749a2f3c717cec491552bbf
 - name: github.com/goware/urlx
   version: 8ce059c8488383d3d5d917e99b51e5487b012698
+- name: github.com/hashicorp/golang-lru
+  version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
+  subpackages:
+  - simplelru
 - name: github.com/jmespath/go-jmespath
   version: 3433f3ea46d9f8019119e7dd41274e112a2359a9
+- name: github.com/jonboulle/clockwork
+  version: 3f831b65b61282ba6bece21b91beea2edc4c887a
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kelseyhightower/envconfig
@@ -169,17 +225,30 @@ imports:
   subpackages:
   - pbutil
 - name: github.com/mitchellh/mapstructure
-  version: 916b5f23bc2f603eb9012f48efd9e38287e71ed5
+  version: 14428cd8e72132155ec2f0f13c4eb93ffe620f7c
 - name: github.com/ncw/swift
   version: 10cc4abfa7125aeaa6de57dd9ea6805c5b37285b
+- name: github.com/opencontainers/go-digest
+  version: 4b560741809dd10de7b455081e356258c70270d0
 - name: github.com/opencontainers/runc
-  version: 7ca2aa4873aea7cb4265b1726acb24b90d8726c6
+  version: baf6536d6259209c3edfa2b22237af82942d3dfa
   subpackages:
   - libcontainer
+  - libcontainer/apparmor
   - libcontainer/cgroups
   - libcontainer/cgroups/fs
+  - libcontainer/cgroups/systemd
   - libcontainer/configs
+  - libcontainer/configs/validate
+  - libcontainer/criurpc
+  - libcontainer/keys
+  - libcontainer/label
+  - libcontainer/seccomp
+  - libcontainer/selinux
+  - libcontainer/stacktrace
   - libcontainer/system
+  - libcontainer/user
+  - libcontainer/utils
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/prometheus/client_golang
@@ -201,13 +270,13 @@ imports:
 - name: github.com/prometheus/procfs
   version: 490cc6eb5fa45bf8a8b7b73c8bc82a8160e8531d
 - name: github.com/PuerkitoBio/purell
-  version: 44968752391892e1b0d0b821ee79e9a85fa13049
+  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
-  version: de5bf2ad457846296e2031421a34e2568e304e35
-- name: github.com/satori/go.uuid
-  version: b2ce2384e17bbe0c6d34077efa39dbab3e09123b
+  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+- name: github.com/Sirupsen/logrus
+  version: 51fe59aca108dc5680109e7b2051cbdcfa5a253c
 - name: github.com/sirupsen/logrus
-  version: 91ef3ab5d512bff80650991a0291c9ad8ebe2219
+  version: e8e563a8238de839b9cbbc1d9807d140a5a24a8d
 - name: github.com/spf13/pflag
   version: 8e7dc108ab3a1ab6ce6d922bbaff5657b88e8e49
   repo: https://github.com/spf13/pflag
@@ -228,8 +297,9 @@ imports:
   version: f4485b318aadd133842532f841dc205a8e339d74
   subpackages:
   - codec
+  - codec/codecgen
 - name: go.opencensus.io
-  version: 46dfec7deb6e8c5d4a46f355c0da7c6d6dc59ba4
+  version: df6e2001952312404b06f5f6f03fcb4aec1648e5
   subpackages:
   - internal
   - internal/tagencoding
@@ -257,6 +327,7 @@ imports:
   version: 49e6db1c9ed2b2fdbc57fd579f0ca8f6082350be
   subpackages:
   - context
+  - context/ctxhttp
   - http2
   - http2/hpack
   - idna
@@ -277,7 +348,13 @@ imports:
 - name: golang.org/x/text
   version: c4d099d611ac3ded35360abf03581e13d91c828f
   subpackages:
+  - cases
+  - internal
+  - internal/tag
+  - language
+  - runes
   - secure/bidirule
+  - secure/precis
   - transform
   - unicode/bidi
   - unicode/norm
@@ -297,7 +374,7 @@ imports:
   - transport/http
   - transport/http/internal/propagation
 - name: google.golang.org/appengine
-  version: 553959209a20f3be281c16dd5be5c740a893978f
+  version: 4f7eeb5305a4ba1966344836ba4af9996b7b4e05
   subpackages:
   - internal
   - internal/app_identity
@@ -309,13 +386,15 @@ imports:
   - internal/urlfetch
   - urlfetch
 - name: google.golang.org/cloud
-  version: 2e43671e4ad874a7bca65746ff3edb38e6e93762
+  version: eb47ba841d53d93506cfbfbc03927daf9cc48f88
   subpackages:
   - compute/metadata
   - internal
+  - internal/opts
+  - internal/transport
   - storage
 - name: google.golang.org/genproto
-  version: c45acf45369a9d2fa234d9508b092aefb9cb9385
+  version: b979b6f78d84775ef7a93ffc8034924947960f29
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
@@ -324,6 +403,7 @@ imports:
   - codes
   - connectivity
   - credentials
+  - credentials/oauth
   - grpclb/grpc_lb_v1/messages
   - grpclog
   - internal
@@ -336,7 +416,7 @@ imports:
   - tap
   - transport
 - name: google.golang.org/protobuf
-  version: b57aae9defbc3e3ce7daed74b0c4d7a57550c933
+  version: 4d5be764fb4e29cb616c984fb923b75b8d1031c6
   subpackages:
   - encoding/prototext
   - encoding/protowire
@@ -368,25 +448,35 @@ imports:
   - types/known/anypb
   - types/known/durationpb
   - types/known/timestamppb
+- name: gopkg.in/inf.v0
+  version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
   version: eca94c41d994ae2215d455ce578ae6e2dc6ee516
 - name: k8s.io/kubernetes
-  version: 3eed1e3be6848b877ff80a93da3785d9034d0a4f
+  version: 9fab05fe59fb4e02deb0f839ae2ae79954bbda4c
   subpackages:
   - pkg/api
   - pkg/api/endpoints
   - pkg/api/errors
   - pkg/api/install
   - pkg/api/meta
+  - pkg/api/meta/metatypes
   - pkg/api/pod
   - pkg/api/resource
   - pkg/api/service
   - pkg/api/unversioned
+  - pkg/api/unversioned/validation
   - pkg/api/util
   - pkg/api/v1
   - pkg/api/validation
   - pkg/apimachinery
   - pkg/apimachinery/registered
+  - pkg/apis/apps
+  - pkg/apis/apps/install
+  - pkg/apis/apps/v1alpha1
+  - pkg/apis/authentication.k8s.io
+  - pkg/apis/authentication.k8s.io/install
+  - pkg/apis/authentication.k8s.io/v1beta1
   - pkg/apis/authorization
   - pkg/apis/authorization/install
   - pkg/apis/authorization/v1beta1
@@ -396,15 +486,22 @@ imports:
   - pkg/apis/batch
   - pkg/apis/batch/install
   - pkg/apis/batch/v1
+  - pkg/apis/batch/v2alpha1
+  - pkg/apis/certificates
+  - pkg/apis/certificates/install
+  - pkg/apis/certificates/v1alpha1
   - pkg/apis/componentconfig
   - pkg/apis/componentconfig/install
   - pkg/apis/componentconfig/v1alpha1
   - pkg/apis/extensions
   - pkg/apis/extensions/install
   - pkg/apis/extensions/v1beta1
-  - pkg/apis/metrics
-  - pkg/apis/metrics/install
-  - pkg/apis/metrics/v1alpha1
+  - pkg/apis/policy
+  - pkg/apis/policy/install
+  - pkg/apis/policy/v1alpha1
+  - pkg/apis/rbac
+  - pkg/apis/rbac/install
+  - pkg/apis/rbac/v1alpha1
   - pkg/auth/user
   - pkg/capabilities
   - pkg/client/cache
@@ -413,24 +510,35 @@ imports:
   - pkg/client/transport
   - pkg/client/typed/discovery
   - pkg/client/unversioned
+  - pkg/client/unversioned/clientcmd/api
   - pkg/controller/framework
   - pkg/conversion
   - pkg/conversion/queryparams
   - pkg/fields
   - pkg/kubelet/qos
+  - pkg/kubelet/types
   - pkg/labels
   - pkg/master/ports
   - pkg/runtime
   - pkg/runtime/serializer
   - pkg/runtime/serializer/json
+  - pkg/runtime/serializer/protobuf
   - pkg/runtime/serializer/recognizer
+  - pkg/runtime/serializer/streaming
   - pkg/runtime/serializer/versioning
   - pkg/types
   - pkg/util
+  - pkg/util/clock
+  - pkg/util/config
+  - pkg/util/crypto
   - pkg/util/errors
+  - pkg/util/flowcontrol
+  - pkg/util/framer
   - pkg/util/hash
   - pkg/util/integer
   - pkg/util/intstr
+  - pkg/util/json
+  - pkg/util/labels
   - pkg/util/net
   - pkg/util/net/sets
   - pkg/util/parsers
@@ -443,8 +551,11 @@ imports:
   - pkg/util/yaml
   - pkg/version
   - pkg/watch
-  - pkg/watch/json
-  - third_party/forked/reflect
+  - pkg/watch/versioned
+  - plugin/pkg/client/auth
+  - plugin/pkg/client/auth/gcp
+  - plugin/pkg/client/auth/oidc
+  - third_party/forked/golang/reflect
 - name: speter.net/go/exp/math/dec/inf
   version: 46a40649338836f5d25521ce343379da79ef2184
   repo: https://github.com/belua/inf

--- a/glide.yaml
+++ b/glide.yaml
@@ -23,7 +23,7 @@ import:
 - package: github.com/codegangsta/cli
   version: a65b733b303f0055f8d324d805f393cd3e7a7904
 - package: k8s.io/kubernetes
-  version: 1.2.4
+  version: 1.4.0-alpha.2
 - package: github.com/arschles/assert
   version: 6882f85ccdc7c1822b146d1a6b0c2c48f91b5140
 - package: github.com/docker/distribution

--- a/glide.yaml
+++ b/glide.yaml
@@ -23,7 +23,9 @@ import:
 - package: github.com/codegangsta/cli
   version: a65b733b303f0055f8d324d805f393cd3e7a7904
 - package: k8s.io/kubernetes
-  version: 1.4.0-alpha.2
+  version: v1.4.12
+- package: k8s.io/client-go
+  version: release-1.4
 - package: github.com/arschles/assert
   version: 6882f85ccdc7c1822b146d1a6b0c2c48f91b5140
 - package: github.com/docker/distribution

--- a/pkg/k8s/watch.go
+++ b/pkg/k8s/watch.go
@@ -26,7 +26,7 @@ type PodWatcher struct {
 func NewPodWatcher(c *client.Client, ns string) *PodWatcher {
 	pw := &PodWatcher{}
 
-	pw.Store.Store, pw.Controller = framework.NewIndexerInformer(
+	pw.Store.Indexer, pw.Controller = framework.NewIndexerInformer(
 		&cache.ListWatch{
 			ListFunc:  podListFunc(c, ns),
 			WatchFunc: podWatchFunc(c, ns),

--- a/pkg/k8s/watch.go
+++ b/pkg/k8s/watch.go
@@ -6,7 +6,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/cache"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
-	"k8s.io/kubernetes/pkg/controller/framework"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch"
@@ -19,21 +18,21 @@ var (
 //PodWatcher is a struct which holds the return values of (k8s.io/kubernetes/pkg/controller/framework).NewIndexerInformer together.
 type PodWatcher struct {
 	Store      cache.StoreToPodLister
-	Controller *framework.Controller
+	Controller *cache.Controller
 }
 
 //NewPodWatcher creates a new BuildPodWatcher useful to list the pods using a cache which gets updated based on the watch func.
 func NewPodWatcher(c *client.Client, ns string) *PodWatcher {
 	pw := &PodWatcher{}
 
-	pw.Store.Indexer, pw.Controller = framework.NewIndexerInformer(
+	pw.Store.Indexer, pw.Controller = cache.NewIndexerInformer(
 		&cache.ListWatch{
 			ListFunc:  podListFunc(c, ns),
 			WatchFunc: podWatchFunc(c, ns),
 		},
 		&api.Pod{},
 		resyncPeriod,
-		framework.ResourceEventHandlerFuncs{},
+		cache.ResourceEventHandlerFuncs{},
 		cache.Indexers{},
 	)
 


### PR DESCRIPTION
Upgrading k8s.io/kubernetes package to latest before pkg/unversioned client changed to pkg/restclient