### PR TITLE
chore(Dockerfile): update hephy/base to v0.5.0

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM hephy/base:v0.4.1
+FROM hephy/base:v0.5.0
 
 RUN adduser --system \
 	--shell /bin/bash \


### PR DESCRIPTION
 - updating to new hephy/base image tag `v0.5.0` with ubuntu 20.04 lts
